### PR TITLE
Fix vercel deployment missing build directory

### DIFF
--- a/Frontend/dist/index.html
+++ b/Frontend/dist/index.html
@@ -9,6 +9,6 @@
     <link rel="stylesheet" crossorigin href="/assets/index-CaWHZvbm.css">
   </head>
   <body class="bg-navy " >
-    <div id="root"></div>
+    <div id="root"></div>
   </body>
 </html>

--- a/Frontend/dist/netlify.toml
+++ b/Frontend/dist/netlify.toml
@@ -1,16 +1,1 @@
-<<<<<<< Current (Your changes)
 # Netlify config has moved to the project root. This file is intentionally empty.
-=======[build]
-  base = "Frontend"
-  command = "npm run build"
-  publish = "dist"
-
-[build.environment]
-  NODE_VERSION = "18"
-
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
-# Netlify config has moved to the project root. This file is intentionally empty.
->>>>>>> Incoming (Background Agent changes)

--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+  base: '/',
 })

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "builds": [
     {
-      "src": "frontend/package.json",
+      "src": "Frontend/package.json",
       "use": "@vercel/static-build",
       "config": { "distDir": "dist" }
     }


### PR DESCRIPTION
Fix Vercel deployment error by correcting frontend path casing and explicitly setting Vite's output directory to `dist`.

The Vercel deployment failed because it expected a `build` directory (common for CRA), while the Vite application outputs to `dist`. Additionally, the `vercel.json` file had an incorrect casing for the `Frontend` directory, preventing Vercel from correctly locating the build source. These changes align the configuration with the Vite build output.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ffb45ff-c869-41eb-ba0e-472d52e201a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ffb45ff-c869-41eb-ba0e-472d52e201a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

